### PR TITLE
Some changing for cropping

### DIFF
--- a/main/Analysis/CoreAnalyzer.py
+++ b/main/Analysis/CoreAnalyzer.py
@@ -102,6 +102,12 @@ class CoreAnalyzer:
         self.trans = TwoDimVec([trans[i][1] for i in range(len(trans))],
                                [trans[i][0] for i in range(len(trans))]).force_signal_to_start_at_zero()
 
+        ## I need to be sure that incid is realy incid and transmitted realy transmitted
+        ## Logic is next: min(incident) signal must be less than min(trans)
+
+        if min(self.incid.y) > min(self.trans.y):
+            self.incid.y, self.trans.y = self.trans.y, self.incid.y
+
         if thermal_analysis:
             self.IR_EXP = TwoDimVec([IR_EXP[i][1] for i in range(len(IR_EXP))],
                                     [IR_EXP[i][0] for i in range(len(IR_EXP))]).force_signal_to_start_at_zero()

--- a/main/Analysis/SignalProcessing.py
+++ b/main/Analysis/SignalProcessing.py
@@ -163,10 +163,10 @@ def auto_crop(update_logger, CA):
     time_reflected = CA.incid_og.x[reflected_before_idx - CA.spacing: reflected_after_idx + CA.spacing]
 
     #   For transmitted wave:
-    #trans_threshold = 0.01 * max_trans
-    #trans_before_idx = peaks_trans[0]
-    #while K * CA.trans_og.y[trans_before_idx] < - trans_threshold:
-    #    trans_before_idx -= 1
+    trans_threshold = 0.01 * max_trans
+    trans_before_idx_real = peaks_trans[0]
+    while K * CA.trans_og.y[trans_before_idx_real] < - trans_threshold:
+        trans_before_idx_real -= 1
 
     # Calculate the beginning of transition wave based on 
     # first strain gage position, second strain gage position
@@ -175,8 +175,13 @@ def auto_crop(update_logger, CA):
 
     trans_before_idx = incid_before_idx + int((CA.first_gage+CA.second_gage+CA.specimen_length)/CA.sound_velocity*2e+6)
 
+    # Here I add the CA.trans_shift parameter to understand how many points
+    # between transmitted signal risng and its beginning by sound velocity calculation
+    # It is important to cut the stress-strain curve
+
     #   Total cropping time
     trans_after_idx = trans_before_idx + signal_time
+    CA.trans_shift = trans_before_idx_real - trans_before_idx
 
     '''
             uncomment the following to display where the cropping occurs.

--- a/main/Analysis/SignalProcessing.py
+++ b/main/Analysis/SignalProcessing.py
@@ -139,29 +139,41 @@ def auto_crop(update_logger, CA):
     while K * CA.incid_og.y[incid_after_idx] < - incid_threshold:
         incid_after_idx += 1
 
-    vcc_incid = CA.incid_og.y[incid_before_idx - CA.spacing: incid_after_idx + 2 * CA.spacing]
-    time_incid = CA.incid_og.x[incid_before_idx - CA.spacing: incid_after_idx + 2 * CA.spacing]
+    vcc_incid = CA.incid_og.y[incid_before_idx - CA.spacing: incid_after_idx + CA.spacing]
+    time_incid = CA.incid_og.x[incid_before_idx - CA.spacing: incid_after_idx + CA.spacing]
 
     #   We want all three waves to be of the same vector size, so we will use the total time of the incident wave,
     #   and only find where the other two waves begin.
     signal_time = incid_after_idx - incid_before_idx
 
     #   For reflected wave:
-    reflected_before_idx = peaks_incid[1]
-    while K * CA.incid_og.y[reflected_before_idx] > incid_threshold:
-        reflected_before_idx -= 1
+    #reflected_before_idx = peaks_incid[1]
+    #while K * CA.incid_og.y[reflected_before_idx] > incid_threshold:
+    #    reflected_before_idx -= 1
+
+    # Calculate the beginning of reflected wave based on 
+    # first strain gage position and soun velocity
+
+    reflected_before_idx = incid_before_idx + int(CA.first_gage*2/CA.sound_velocity*2e+6)
 
     #   Total cropping time
     reflected_after_idx = reflected_before_idx + signal_time
     reflected_idx = reflected_before_idx
-    vcc_reflected = CA.incid_og.y[reflected_before_idx - CA.spacing: reflected_after_idx + 2 * CA.spacing]
-    time_reflected = CA.incid_og.x[reflected_before_idx - CA.spacing: reflected_after_idx + 2 * CA.spacing]
+    vcc_reflected = CA.incid_og.y[reflected_before_idx - CA.spacing: reflected_after_idx + CA.spacing]
+    time_reflected = CA.incid_og.x[reflected_before_idx - CA.spacing: reflected_after_idx + CA.spacing]
 
     #   For transmitted wave:
-    trans_threshold = 0.01 * max_trans
-    trans_before_idx = peaks_trans[0]
-    while K * CA.trans_og.y[trans_before_idx] < - trans_threshold:
-        trans_before_idx -= 1
+    #trans_threshold = 0.01 * max_trans
+    #trans_before_idx = peaks_trans[0]
+    #while K * CA.trans_og.y[trans_before_idx] < - trans_threshold:
+    #    trans_before_idx -= 1
+
+    # Calculate the beginning of transition wave based on 
+    # first strain gage position, second strain gage position
+    # and soun velocity, I add also length of the specimen
+    # better if it will be sound velocity of the sample, but we don't know it
+
+    trans_before_idx = incid_before_idx + int((CA.first_gage+CA.second_gage+CA.specimen_length)/CA.sound_velocity*2e+6)
 
     #   Total cropping time
     trans_after_idx = trans_before_idx + signal_time
@@ -179,8 +191,8 @@ def auto_crop(update_logger, CA):
     plt.show()
     '''
 
-    vcc_trans = CA.trans_og.y[trans_before_idx - CA.spacing: trans_after_idx + 2 * CA.spacing]
-    time_trans = CA.trans_og.x[trans_before_idx - CA.spacing: trans_after_idx + 2 * CA.spacing]
+    vcc_trans = CA.trans_og.y[trans_before_idx - CA.spacing: trans_after_idx + CA.spacing]
+    time_trans = CA.trans_og.x[trans_before_idx - CA.spacing: trans_after_idx + CA.spacing]
 
     zeroing([time_incid, time_reflected, time_trans])
 

--- a/main/Calculators/FinalCalculation.py
+++ b/main/Calculators/FinalCalculation.py
@@ -70,8 +70,10 @@ def final_calculation(update_logger, CA):
     if idx == 0:
         idx = len(eng_strain)
 
-    eng_strain = abs(eng_strain[:idx])
-    eng_stress = eng_stress[:idx]
+    # Here I am cut the stress-strain curves and shift it according "CA.trans_shift" parameter    
+
+    eng_strain = abs(eng_strain[CA.trans_shift+CA.spacing:idx]) - abs(eng_strain[CA.trans_shift+CA.spacing])
+    eng_stress = eng_stress[CA.trans_shift+CA.spacing:idx] - eng_stress[CA.trans_shift+CA.spacing]
 
     #   Calculate the average (mean) striker velocity:
     CA.mean_striker_velocity = SignalProcessing.mean_of_signal(update_logger,
@@ -127,7 +129,7 @@ def final_calculation(update_logger, CA):
     else:
         K = 1
 
-    for i in range(idx):
+    for i in range(len(eng_strain)):
         surf_spec_inst.append(abs(specimen_surface / (1 + K * strain[i])))
         true_stress.append(abs(eng_stress[i] * (1 + K * strain[i])))
         true_strain.append(abs(np.log(1 + K * strain[i])))


### PR DESCRIPTION
Changed length of cropped signal from 2*CA.spacing for only CA.spacing in all three Signals

Changed the method of auto-cropping with idea that time between incident and reflected signals equal to two times of wave propagation from gage to bar side and time between incident and transmitted signals equal to time of wave propagating from first gage to second gage. It is only one problem with specimen's sound velocity, because we don't know it, so usage the bar's sound velocity for the specimen is a better than nothing.

But there is some problems with Stress-Strain curve.

In case the F_in far from F_out curves shows some non physical strain which should be skipped.
It is work to do